### PR TITLE
Reexport abort and kernel_irq_handler

### DIFF
--- a/src/kernel/main.rs
+++ b/src/kernel/main.rs
@@ -17,6 +17,9 @@ mod debug;      /* get us some kind of debug output, typically to a serial port 
 mod irq;        /* handle hw interrupts and sw exceptions, collectively known as IRQs */
 mod abort;      /* implement abort() and panic() handlers */
 
+pub use abort::abort;
+pub use irq::kernel_irq_handler;
+
 /* kmain
    The boot CPU core branches here when ready.
    => device_tree_buf = phys RAM pointer to device tree describing the hardware


### PR DESCRIPTION
When trying to compile the kernel I've got an error:
```
kernel.eylniip0-cgu.0:(.text._ZN4core6result13unwrap_failed17h039c92a70aa18ed7E+0x56): undefined
reference to `abort'
```

These symbols buried in abort and irq modules respectively and I suppose it prevents linker to find
these symbols.