### PR TITLE
Document branching model

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ hypervisor written in [Zig](https://ziglang.org/) for 64-bit
 [RISC-V](https://riscv.org/developers/) computers. It is aimed at systems small and large that
 have a need to run multiple hardware-isolated operating systems at the same time.
 
-Below is a recording of a user logging into a RISC-V Linux guest OS on Diosix and running a few commands.
+Here's a recording of a user logging into a RISC-V Linux guest OS running on Diosix and trying out a few commands.
 
 [![asciicast](https://asciinema.org/a/1161817.svg)](https://asciinema.org/a/1161817)
 
@@ -19,7 +19,7 @@ privileged Linux-based Root Virtual Machine (Root VM) for managing the host
 hardware and orchestrating other guest workloads.
 
 For a deeper dive into this type-1 hypervisor's design, see the 
-[background information](docs/background.md) documentation.
+[technical documentation](docs/background.md).
 
 ### Supported hardware
 
@@ -27,7 +27,7 @@ Diosix runs on RVA20-compliant (RV64GC) systems, automatically adapting its isol
 
 ## Build Diosix
 
-To build Diosix, you must have at least version 0.16.0 of the 
+To build Diosix, you must have at least version 0.17.0 of the 
 [Zig toolchain](https://ziglang.org/download/) and [Git](https://git.kernel.org/pub/scm/git/git.git/) version 2.54 installed.
 
 Follow these steps to build the hypervisor from source:
@@ -35,7 +35,7 @@ Follow these steps to build the hypervisor from source:
 1. Clone the repository and enter the project directory:
 
    ```bash
-   git clone --branch zig https://github.com/diodesign/diosix.git
+   git clone --branch stable https://github.com/diodesign/diosix.git
    cd diosix
    ```
 
@@ -51,7 +51,7 @@ For a detailed explanation of the compilation process, declarative hardware conf
 
 ### Root VM image
 
-The build process automatically downloads and cross-compiles [BuildRoot](https://buildroot.org/) if the Root VM image is missing or needs updating. Because we build everything 
+The build process automatically downloads and cross-compiles [BuildRoot](https://buildroot.org/) if the Root VM image is missing or needs updating. Because Diosix builds everything 
 from source for an absolute guarantee of provenance and security, this initial 
 BuildRoot step can take significant time to compile the Linux kernel, a busybox 
 userspace, and the cross-compiler toolchain. Subsequent builds rely on the 
@@ -61,13 +61,13 @@ cached output.
 
 Diosix relies on a modular, declarative hardware configuration model. Available hardware ports are defined inside target configuration YAML files located in `hypervisor/hw/ports/`, such as `qemu-virt.yaml`.
 
-The default target system is specified in `hypervisor/hw/ports/default.yaml`, which defaults to `qemu-virt`. To compile for a different target hardware system, specify the target name using the `-Dsystem` parameter like so:
+The default target system is specified in `hypervisor/hw/ports/default.yaml`, which defaults to `qemu-virt`. To compile for a different target hardware system, specify the target name using the `-Dsystem` parameter. For example, to target a PMP-only Qemu-simulated system, use:
 
 ```bash
-./scripts/build.sh -Dsystem=qemu-virt
+./scripts/build.sh -Dsystem=qemu-virt-pmp
 ```
 
-You can view all dynamically discovered target hardware systems and build options by running:
+You can view all dynamically discovered target hardware systems and other build options by running:
 
 ```bash
 ./scripts/build.sh -h
@@ -123,9 +123,14 @@ Finally, we use the
 where even-numbered minor versions indicate stable releases and odd numbers 
 represent development builds.
 
-### ZLS integration
+### Branching model
 
-The [Zig Language Server](https://zigtools.org/zls/) (ZLS) works out-of-the-box with this project. During diagnostics and background checks, `build.zig` gracefully falls back to `"unknown"` placeholders for any missing environment-derived metadata, such as the current git revision or build date. This prevents background compilation failures and ensures autocomplete and diagnostics function perfectly without requiring any custom wrapper scripts or IDE configurations.
+The project maintains two primary branches to orchestrate development and releases:
+
+* **`stable`**: The branch representing production-ready code. Releases are created directly from this branch, and it is also the source branch used to build the official project website, [diosix.org](https://diosix.org/).
+* **`devel`**: The active staging branch for development and ongoing feature additions.
+
+Development workflows should target the `devel` branch. Changes are only merged from `devel` into `stable` after completing rigorous testing, quality control, and validation.
 
 ## Contact and community
 

--- a/build.zig
+++ b/build.zig
@@ -224,7 +224,7 @@ pub fn build(b: *std.Build) !void {
     const test_metadata_obj = b.addObject(.{
         .name = "metadata_info_test",
         .root_module = b.createModule(.{
-            .root_source_file = b.path("hypervisor/core/metadata_info.zig"),
+            .root_source_file = b.path("hypervisor/core/metadata.zig"),
             .optimize = optimize,
             .target = b.graph.host,
         }),


### PR DESCRIPTION
Updated the project's contribution documentation to detail the branching model and refined build targets for unit test metadata resolution.

- Added 'Branching model' section to README.md explaining the roles of the 'stable' (production-ready releases and website) and 'devel' (staging and active development) branches.
- Updated git clone instructions in README.md to clone '--branch stable'.
- Fixed unit test metadata target in build.zig to resolve compilation against the renamed 'hypervisor/core/metadata.zig' module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request documents the project's branching model and fixes a unit test compilation issue. The changes introduce a "Branching model" section to README.md that clarifies the roles of two branches: `stable` for production-ready releases and website source, and `devel` for active development and staging. Build instructions are updated to recommend cloning with `--branch stable`. The minimum required Zig toolchain version is raised to 0.17.0, and build-target documentation is enhanced with a concrete example showing how to target PMP-only systems. Additionally, build.zig is corrected to reference the renamed module `hypervisor/core/metadata.zig` for unit test metadata compilation, ensuring the test build resolves properly against the correct source file.

| File Path | Change Type | Reason for Change | Change Impact for Users |
|-----------|-------------|-------------------|------------------------|
| README.md | Documentation | Establish clear branching strategy and document the roles of stable vs. devel branches; update build instructions to reference the correct stable branch; increase minimum Zig version requirement; enhance build documentation with concrete examples | Non-breaking: Users following the documented workflow will clone from `stable` by default; clarifies development workflow expectations |
| build.zig | Bugfix | Fix unit test metadata compilation to resolve against the renamed `hypervisor/core/metadata.zig` module instead of the outdated `hypervisor/core/metadata_info.zig` path | Non-breaking: Enables unit tests to compile successfully; ensures metadata is properly included in host test builds |

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diodesign/diosix/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->