### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - devel
       - stable
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu-build:
     name: Ubuntu 22.04 build and test


### PR DESCRIPTION
Potential fix for [https://github.com/diodesign/diosix/security/code-scanning/2](https://github.com/diodesign/diosix/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access unless overridden.  
Best fix here (without changing functionality): add:

```yml
permissions:
  contents: read
```

right after the trigger section (`on:` block) and before `jobs:`.  
This documents intent, prevents drift if repo defaults change, and satisfies CodeQL with minimal impact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
